### PR TITLE
Connect PM2 to Keymetrics when setting up pm2

### DIFF
--- a/3i-nodejs/recipes/setup-pm2.rb
+++ b/3i-nodejs/recipes/setup-pm2.rb
@@ -6,3 +6,8 @@ execute "setup-pm2-startup-script" do
   command 'env PATH=$PATH:/usr/bin pm2 startup ubuntu -u ubuntu --hp /home/ubuntu'
   user 'root'
 end
+
+execute "connect-pm2-to-keymetrics" do 
+  command 'pm2 link $KEYMETRICS_SECRET $KEYMETRICS_PUBLIC'
+  user 'root'
+end


### PR DESCRIPTION
I think we need this in our chef cookbooks to ensure we connect up to KeyMetrics every time we do a deploy or setup a new opsworks machine.

I've setup the two env variables listed here in opsworks. 

Think they should be automatically available to this command like this?

cc @KeeganJ and @RyanMcMahon