### PR TITLE
Tuesday, July 31 Release: Add build step to node projects, remove keymetrics install.

### DIFF
--- a/3i-deploy/recipes/deploy-nodejs-CLI.rb
+++ b/3i-deploy/recipes/deploy-nodejs-CLI.rb
@@ -58,6 +58,12 @@ node[:deploy].each do |application, deploy|
     action :delete
   end
 
+  execute 'build' do
+    command 'npm run build'
+    if { deploy['environment_variables']['REQUIRES_BUILD'] == 'true' }
+    user 'ubuntu'
+  end
+
   # Then copy in place a crontab from the repo if one was provided
   execute 'setup crontab' do
     command <<-COMMANDS

--- a/3i-deploy/recipes/deploy-nodejs-CLI.rb
+++ b/3i-deploy/recipes/deploy-nodejs-CLI.rb
@@ -60,7 +60,7 @@ node[:deploy].each do |application, deploy|
 
   execute 'build' do
     command 'npm run build'
-    if { deploy['environment_variables']['REQUIRES_BUILD'] == 'true' }
+    only_if { deploy['environment_variables']['REQUIRES_BUILD'] == 'true' }
     user 'ubuntu'
   end
 

--- a/3i-deploy/recipes/deploy-nodejs-CLI.rb
+++ b/3i-deploy/recipes/deploy-nodejs-CLI.rb
@@ -59,7 +59,7 @@ node[:deploy].each do |application, deploy|
   end
 
   execute 'build' do
-    command 'npm run build'
+    command "cd #{deploy[:deploy_to]}/current && npm run build"
     only_if { deploy['environment_variables']['REQUIRES_BUILD'] == 'true' }
     user 'root'
   end

--- a/3i-deploy/recipes/deploy-nodejs-CLI.rb
+++ b/3i-deploy/recipes/deploy-nodejs-CLI.rb
@@ -61,7 +61,7 @@ node[:deploy].each do |application, deploy|
   execute 'build' do
     command 'npm run build'
     only_if { deploy['environment_variables']['REQUIRES_BUILD'] == 'true' }
-    user 'ubuntu'
+    user 'root'
   end
 
   # Then copy in place a crontab from the repo if one was provided

--- a/3i-deploy/recipes/deploy-nodejs-PM2.rb
+++ b/3i-deploy/recipes/deploy-nodejs-PM2.rb
@@ -50,7 +50,7 @@ node[:deploy].each do |application, deploy|
   execute 'build' do
     command 'npm run build'
     only_if { deploy['environment_variables']['REQUIRES_BUILD'] == 'true' }
-    user 'ubuntu'
+    user 'root'
   end
 
   execute 'start_or_restart_cronjs' do

--- a/3i-deploy/recipes/deploy-nodejs-PM2.rb
+++ b/3i-deploy/recipes/deploy-nodejs-PM2.rb
@@ -48,7 +48,7 @@ node[:deploy].each do |application, deploy|
   end
 
   execute 'build' do
-    command 'npm run build'
+    command "cd #{deploy[:deploy_to]}/current && npm run build"
     only_if { deploy['environment_variables']['REQUIRES_BUILD'] == 'true' }
     user 'root'
   end

--- a/3i-deploy/recipes/deploy-nodejs-PM2.rb
+++ b/3i-deploy/recipes/deploy-nodejs-PM2.rb
@@ -49,7 +49,7 @@ node[:deploy].each do |application, deploy|
 
   execute 'build' do
     command 'npm run build'
-    if { deploy['environment_variables']['REQUIRES_BUILD'] == 'true' }
+    only_if { deploy['environment_variables']['REQUIRES_BUILD'] == 'true' }
     user 'ubuntu'
   end
 

--- a/3i-deploy/recipes/deploy-nodejs-PM2.rb
+++ b/3i-deploy/recipes/deploy-nodejs-PM2.rb
@@ -47,6 +47,12 @@ node[:deploy].each do |application, deploy|
     user 'ubuntu'
   end
 
+  execute 'build' do
+    command 'npm run build'
+    if { deploy['environment_variables']['REQUIRES_BUILD'] == 'true' }
+    user 'ubuntu'
+  end
+
   execute 'start_or_restart_cronjs' do
     command "env HOME=`eval echo \"~ubuntu\"` pm2 startOrRestart #{deploy[:deploy_to]}/current/pm2-app.json"
     not_if { deploy['environment_variables']['DISABLED'] == "true" }

--- a/3i-nodejs/recipes/setup-pm2.rb
+++ b/3i-nodejs/recipes/setup-pm2.rb
@@ -22,15 +22,3 @@ execute "link-pm2-to-keymetrics" do
   user 'ubuntu'
   environment ({'HOME' => '/home/ubuntu'})
 end
-
-execute "setup-keymetrics-server-monitoring" do
-  command 'pm2 install pm2-server-monit'
-  user 'root'
-  environment ({'HOME' => '/home/ubuntu'})
-end
-
-execute "install-pm2-typescript-runner" do
-  command 'pm2 install typescript'
-  user 'root'
-  environment ({'HOME' => '/home/ubuntu'})
-end


### PR DESCRIPTION
[BZ-4843](https://thirdiron.atlassian.net/browse/BZ-4843) : 
https://github.com/thirdiron/browzine_metadata_collector/pull/185

This configuration has been tested in staging for a couple weeks now. We don't always do PRs or deployments on this project, but this could be a good thing to get a second set of eyes on.

This PR should be merged before MC is deployed.