### PR TITLE
Feature/add old deployment cleanup

### DIFF
--- a/3i-deploy/recipes/deploy-nodejs-CLI.rb
+++ b/3i-deploy/recipes/deploy-nodejs-CLI.rb
@@ -74,5 +74,15 @@ node[:deploy].each do |application, deploy|
     user 'root'
   end
 
+  # Also make sure a crontab is in place to delete old deployment folders of this application
+  template "/etc/cron.d/#{application}_cleanup_old_releases_crontab" do
+    source 'cleanup_old_releases_crontab.erb'
+    variables({
+      :releases_folder_path => File.join(deploy[:deploy_to], 'releases')
+    })
+  end
+
+
+
 end
 

--- a/3i-deploy/recipes/deploy-nodejs-PM2.rb
+++ b/3i-deploy/recipes/deploy-nodejs-PM2.rb
@@ -59,4 +59,13 @@ node[:deploy].each do |application, deploy|
     user 'ubuntu'
   end
 
+  # Also make sure a crontab is in place to delete old deployment folders of this application
+  template "/etc/cron.d/#{application}_cleanup_old_releases_crontab" do
+    source 'cleanup_old_releases_crontab.erb'
+    variables({
+      :releases_folder_path => File.join(deploy[:deploy_to], 'releases')
+    })
+  end
+
+
 end

--- a/3i-deploy/recipes/deploy-python-CLI.rb
+++ b/3i-deploy/recipes/deploy-python-CLI.rb
@@ -70,5 +70,14 @@ node[:deploy].each do |application, deploy|
     user 'root'
   end
 
+  # Also make sure a crontab is in place to delete old deployment folders of this application
+  template "/etc/cron.d/#{application}_cleanup_old_releases_crontab" do
+    source 'cleanup_old_releases_crontab.erb'
+    variables({
+      :releases_folder_path => File.join(deploy[:deploy_to], 'releases')
+    })
+  end
+
+
 end
 

--- a/3i-deploy/recipes/nodejs.rb
+++ b/3i-deploy/recipes/nodejs.rb
@@ -68,6 +68,15 @@ node[:deploy].each do |application, deploy|
   end
 
 
+  # Also make sure a crontab is in place to delete old deployment folders of this application
+  template "/etc/cron.d/#{application}_cleanup_old_releases_crontab" do
+    source 'cleanup_old_releases_crontab.erb'
+    variables({
+      :releases_folder_path => File.join(deploy[:deploy_to], 'releases')
+    })
+  end
+
+
   # This seems to only log things instead of actually restart anything
   ruby_block "restart node.js application #{application}" do
     block do
@@ -76,5 +85,6 @@ node[:deploy].each do |application, deploy|
       $? == 0
     end
   end
+
 end
 

--- a/3i-deploy/templates/default/cleanup_old_releases_crontab.erb
+++ b/3i-deploy/templates/default/cleanup_old_releases_crontab.erb
@@ -1,0 +1,26 @@
+SHELL=/bin/bash
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+MAILTO=root
+HOME=/
+
+##########
+##
+##  REMINDER
+##
+##  System Time is in UTC
+##
+##############
+
+
+# For details see man 4 crontabs
+
+# Example of job definition:
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name command to be executed
+
+0 * * * * root cleanup_old_releases.rb <%= @releases_folder_path %>

--- a/3i-server-commons/files/default/cleanup_old_releases.rb
+++ b/3i-server-commons/files/default/cleanup_old_releases.rb
@@ -1,0 +1,30 @@
+#!/usr/local/bin/ruby -w
+
+######
+#
+# Old releases cleanup script.  Pass in the absolute path to 
+# an opsworks application's releases folder and it deletes
+# releases we don't need anymore
+#
+######
+require 'date'
+
+releases_path = ARGV[0] 
+
+release_folders = Dir[releases_path + '/*/'].sort!
+release_folders.pop # Always keep latest release
+
+releases.keep_if {
+  |release|
+  release_timestamp = File.basename(release)
+  # delete deployments after 30 days
+  cut_off_timestamp = (Date.today - 30).strftime('%Y%m%d%H%M%S')
+  is_old = release_timestamp > cut_off_timestamp
+  not is_old
+}
+
+releases.each do |old_release_dir|
+  system("rm -r #{old_release_dir}")
+end
+
+

--- a/3i-server-commons/recipes/setup-common-scripts.rb
+++ b/3i-server-commons/recipes/setup-common-scripts.rb
@@ -4,3 +4,11 @@ cookbook_file '/usr/local/bin/beforeRotateLog.sh' do
   owner 'root'
   group 'root'
 end
+
+# Script used to clean up old deployment folders
+cookbook_file '/usr/local/bin/cleanup_old_releases.rb' do
+  source 'cleanup_old_releases.rb'
+  mode '0755'
+  owner 'root'
+  group 'root'
+end


### PR DESCRIPTION
Updates the 3i-server-commons cookbook to include a script that cleans up opsworks release folders.  Script is written to delete releases older than 30 days, but never delete the latest release.

Then the deployment recipes are updated so that each application deploys a crontab which runs the cleanup script on the application's releases folder once every hour