### PR TITLE
Create .pm2 folder in case it doesn't exist

### DIFF
--- a/3i-nodejs/recipes/setup-pm2.rb
+++ b/3i-nodejs/recipes/setup-pm2.rb
@@ -2,6 +2,13 @@ nodejs_npm "pm2" do
   version "2.10.1"
 end
 
+directory '/home/ubuntu/.pm2' do
+  owner 'ubuntu'
+  group 'root'
+  mode '0755'
+  action :create
+end
+
 # set the modules folder owner to ubuntu
 # so the ubuntu user can actually install modules
 # (like the server monitor module)


### PR DESCRIPTION
For some reason on a fresh install /home/ubuntu/.pm2 doesn't exist so
the following directory resource for /home/ubuntu/.pm2/modules fails