### PR TITLE
Update npm install for nodeJS opsworks apps to receive env vars from opsworks application config

### DIFF
--- a/3i-deploy/definitions/ti_opsworks_cli_nodejs.rb
+++ b/3i-deploy/definitions/ti_opsworks_cli_nodejs.rb
@@ -2,6 +2,14 @@ define :ti_opsworks_cli_nodejs do
   deploy = params[:deploy_data]
   application = params[:app]
 
+  # install package.json depdencencies with an npm install
+  #
+  execute "su #{node[:deploy][application][:user]} -c 'cd #{deploy[:deploy_to]}/current && /usr/bin/npm install'" do
+    cwd "#{deploy[:deploy_to]}/current"
+    user "root"
+    environment node[:deploy][application][:environment_variables]
+  end
+
   node[:dependencies][:npms].each do |npm, version|
     execute "/usr/local/bin/npm install #{npm}" do
       cwd "#{deploy[:deploy_to]}/current"

--- a/3i-deploy/definitions/ti_opsworks_deploy.rb
+++ b/3i-deploy/definitions/ti_opsworks_deploy.rb
@@ -104,15 +104,15 @@ define :ti_opsworks_deploy do
       before_migrate do
         link_tempfiles_to_current_release
 
-        if deploy[:application_type] == 'nodejs' || ( deploy[:application_type] == 'other' && deploy['environment_variables']['OPSWORKS_APPLICATION_TYPE'].include?("nodejs"))
-          # by convention, if application_type is other, look in the
-          # OPSWORKS_APPLICATION_TYPE environment variable.  If 
-          # the value contains "nodejs" it's a custom nodeJS setup and
-          # we need to run npm install in the release directory
-          if deploy[:auto_npm_install_on_deploy]
-            OpsWorks::NodejsConfiguration.npm_install(application, node[:deploy][application], release_path, node[:opsworks_nodejs][:npm_install_options])
-          end
-        end
+#        if deploy[:application_type] == 'nodejs' || ( deploy[:application_type] == 'other' && deploy['environment_variables']['OPSWORKS_APPLICATION_TYPE'].include?("nodejs"))
+#          # by convention, if application_type is other, look in the
+#          # OPSWORKS_APPLICATION_TYPE environment variable.  If 
+#          # the value contains "nodejs" it's a custom nodeJS setup and
+#          # we need to run npm install in the release directory
+#          if deploy[:auto_npm_install_on_deploy]
+#            OpsWorks::NodejsConfiguration.npm_install(application, node[:deploy][application], release_path, node[:opsworks_nodejs][:npm_install_options])
+#          end
+#        end
 
         # run user provided callback file
         run_callback_from_file("#{release_path}/deploy/before_migrate.rb")

--- a/3i-deploy/definitions/ti_opsworks_deploy.rb
+++ b/3i-deploy/definitions/ti_opsworks_deploy.rb
@@ -104,16 +104,6 @@ define :ti_opsworks_deploy do
       before_migrate do
         link_tempfiles_to_current_release
 
-#        if deploy[:application_type] == 'nodejs' || ( deploy[:application_type] == 'other' && deploy['environment_variables']['OPSWORKS_APPLICATION_TYPE'].include?("nodejs"))
-#          # by convention, if application_type is other, look in the
-#          # OPSWORKS_APPLICATION_TYPE environment variable.  If 
-#          # the value contains "nodejs" it's a custom nodeJS setup and
-#          # we need to run npm install in the release directory
-#          if deploy[:auto_npm_install_on_deploy]
-#            OpsWorks::NodejsConfiguration.npm_install(application, node[:deploy][application], release_path, node[:opsworks_nodejs][:npm_install_options])
-#          end
-#        end
-
         # run user provided callback file
         run_callback_from_file("#{release_path}/deploy/before_migrate.rb")
       end

--- a/3i-deploy/definitions/ti_opsworks_nodejs.rb
+++ b/3i-deploy/definitions/ti_opsworks_nodejs.rb
@@ -6,6 +6,14 @@ define :ti_opsworks_nodejs do
     action :nothing
   end
 
+  # install package.json depdencencies with an npm install
+  #
+  execute "su #{node[:deploy][application][:user]} -c 'cd #{deploy[:deploy_to]}/current && /usr/bin/npm install'" do
+    cwd "#{deploy[:deploy_to]}/current"
+    user "root"
+    environment node[:deploy][application][:environment_variables]
+  end
+
   node[:dependencies][:npms].each do |npm, version|
     execute "/usr/local/bin/npm install #{npm}" do
       cwd "#{deploy[:deploy_to]}/current"

--- a/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
+++ b/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
@@ -6,7 +6,7 @@ define :ti_opsworks_pm2_nodejs do
   #
   #
   Chef::Log.info("Trying to install dependencies using user: #{node[:deploy][application][:user]}")
-  execute "su - #{node[:deploy][application][:user]} -c 'cd #{deploy[:deploy_to]}/current && /usr/bin/npm install'" do
+  execute "su #{node[:deploy][application][:user]} -c 'cd #{deploy[:deploy_to]}/current && /usr/bin/npm install'" do
     cwd "#{deploy[:deploy_to]}/current"
     user "root"
     environment node[:deploy][application][:environment_variables]

--- a/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
+++ b/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
@@ -4,7 +4,7 @@ define :ti_opsworks_pm2_nodejs do
 
   # install package.json depdencencies with an npm install
   #
-  execute "/usr/bin/npm install" do
+  execute "cd #{node[:release_path]} && /usr/bin/npm install" do
     cwd node[:release_path]
     user node[:deploy][application][:user]
     environment node[:deploy][application][:environment_variables]

--- a/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
+++ b/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
@@ -4,6 +4,8 @@ define :ti_opsworks_pm2_nodejs do
 
   # install package.json depdencencies with an npm install
   #
+  #
+  Chef::Log.info("Trying to install dependencies using user: #{node[:deploy][application][:user]}")
   execute "cd #{deploy[:deploy_to]}/current && /usr/bin/npm install" do
     cwd "#{deploy[:deploy_to]}/current"
     user node[:deploy][application][:user]

--- a/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
+++ b/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
@@ -6,9 +6,9 @@ define :ti_opsworks_pm2_nodejs do
   #
   #
   Chef::Log.info("Trying to install dependencies using user: #{node[:deploy][application][:user]}")
-  execute "cd #{deploy[:deploy_to]}/current && /usr/bin/npm install" do
+  execute "su - #{node[:deploy][application][:user] -c 'cd #{deploy[:deploy_to]}/current && /usr/bin/npm install'" do
     cwd "#{deploy[:deploy_to]}/current"
-    user node[:deploy][application][:user]
+    user root
     environment node[:deploy][application][:environment_variables]
   end
 

--- a/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
+++ b/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
@@ -4,8 +4,8 @@ define :ti_opsworks_pm2_nodejs do
 
   # install package.json depdencencies with an npm install
   #
-  execute "cd #{node[:release_path]} && /usr/bin/npm install" do
-    cwd node[:release_path]
+  execute "/usr/bin/npm install" do
+    cwd "#{deploy[:deploy_to]}/current"
     user node[:deploy][application][:user]
     environment node[:deploy][application][:environment_variables]
   end

--- a/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
+++ b/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
@@ -5,7 +5,6 @@ define :ti_opsworks_pm2_nodejs do
   # install package.json depdencencies with an npm install
   #
   #
-  Chef::Log.info("Trying to install dependencies using user: #{node[:deploy][application][:user]}")
   execute "su #{node[:deploy][application][:user]} -c 'cd #{deploy[:deploy_to]}/current && /usr/bin/npm install'" do
     cwd "#{deploy[:deploy_to]}/current"
     user "root"

--- a/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
+++ b/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
@@ -6,7 +6,7 @@ define :ti_opsworks_pm2_nodejs do
   #
   #
   Chef::Log.info("Trying to install dependencies using user: #{node[:deploy][application][:user]}")
-  execute "su - #{node[:deploy][application][:user] -c 'cd #{deploy[:deploy_to]}/current && /usr/bin/npm install'" do
+  execute "su - #{node[:deploy][application][:user]} -c 'cd #{deploy[:deploy_to]}/current && /usr/bin/npm install'" do
     cwd "#{deploy[:deploy_to]}/current"
     user root
     environment node[:deploy][application][:environment_variables]

--- a/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
+++ b/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
@@ -8,7 +8,7 @@ define :ti_opsworks_pm2_nodejs do
   Chef::Log.info("Trying to install dependencies using user: #{node[:deploy][application][:user]}")
   execute "su - #{node[:deploy][application][:user]} -c 'cd #{deploy[:deploy_to]}/current && /usr/bin/npm install'" do
     cwd "#{deploy[:deploy_to]}/current"
-    user root
+    user "root"
     environment node[:deploy][application][:environment_variables]
   end
 

--- a/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
+++ b/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
@@ -4,7 +4,7 @@ define :ti_opsworks_pm2_nodejs do
 
   # install package.json depdencencies with an npm install
   #
-  execute "/usr/bin/npm install" do
+  execute "cd #{deploy[:deploy_to]}/current && /usr/bin/npm install" do
     cwd "#{deploy[:deploy_to]}/current"
     user node[:deploy][application][:user]
     environment node[:deploy][application][:environment_variables]

--- a/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
+++ b/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
@@ -2,11 +2,13 @@ define :ti_opsworks_pm2_nodejs do
   deploy = params[:deploy_data]
   application = params[:app]
 
-  # Use the OpsWorks nodeJS configuration library to
-  # invoke npm install
-  Chef::Log.info("Running npm install in directory #{deploy[:deploy_to]}/current")
-  OpsWorks::NodejsConfiguration.npm_install(application, node[:deploy][application], "#{deploy[:deploy_to]}/current", node[:opsworks_nodejs][:npm_install_options])
-
+  # install package.json depdencencies with an npm install
+  #
+  execute "/usr/local/bin/npm install" do
+    cwd node[:release_path]
+    user node[:deploy][application][:user]
+    environment node[:deploy][application][:environment_variables]
+  end
 
   node[:dependencies][:npms].each do |npm, version|
     execute "/usr/local/bin/npm install #{npm}" do

--- a/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
+++ b/3i-deploy/definitions/ti_opsworks_pm2_nodejs.rb
@@ -4,14 +4,14 @@ define :ti_opsworks_pm2_nodejs do
 
   # install package.json depdencencies with an npm install
   #
-  execute "/usr/local/bin/npm install" do
+  execute "/usr/bin/npm install" do
     cwd node[:release_path]
     user node[:deploy][application][:user]
     environment node[:deploy][application][:environment_variables]
   end
 
   node[:dependencies][:npms].each do |npm, version|
-    execute "/usr/local/bin/npm install #{npm}" do
+    execute "/usr/bin/npm install #{npm}" do
       cwd node[:release_path]
     end
   end

--- a/3i-nodejs/recipes/setup-pm2.rb
+++ b/3i-nodejs/recipes/setup-pm2.rb
@@ -4,11 +4,11 @@ end
 
 # Set .pm2 folder permissions so ubuntu user
 # can update things
-directory '/home/ubuntu/.pm2' do
-  owner 'ubuntu'
-  group 'ubuntu'
-  mode '0755'
-end
+#directory '/home/ubuntu/.pm2' do
+#  owner 'ubuntu'
+#  group 'ubuntu'
+#  mode '0755'
+#end
 
 # set the modules folder owner to ubuntu
 # so the ubuntu user can actually install modules

--- a/3i-nodejs/recipes/setup-pm2.rb
+++ b/3i-nodejs/recipes/setup-pm2.rb
@@ -4,11 +4,11 @@ end
 
 # Set .pm2 folder permissions so ubuntu user
 # can update things
-#directory '/home/ubuntu/.pm2' do
-#  owner 'ubuntu'
-#  group 'ubuntu'
-#  mode '0755'
-#end
+directory '/home/ubuntu/.pm2' do
+  owner 'ubuntu'
+  group 'ubuntu'
+  mode '0755'
+end
 
 # set the modules folder owner to ubuntu
 # so the ubuntu user can actually install modules

--- a/3i-nodejs/recipes/setup-pm2.rb
+++ b/3i-nodejs/recipes/setup-pm2.rb
@@ -4,9 +4,10 @@ end
 
 # Set .pm2 folder permissions so ubuntu user
 # can update things
-execute 'setup-pm2-folder-permissions' do
-  command 'chown ubuntu:ubuntu /home/ubuntu/.pm2'
-  user 'root'
+directory '/dome/ubuntu/.pm2' do
+  ownder 'ubuntu'
+  group 'ubuntu'
+  mode '0755'
 end
 
 # set the modules folder owner to ubuntu

--- a/3i-nodejs/recipes/setup-pm2.rb
+++ b/3i-nodejs/recipes/setup-pm2.rb
@@ -5,7 +5,7 @@ end
 # Set .pm2 folder permissions so ubuntu user
 # can update things
 directory '/dome/ubuntu/.pm2' do
-  ownder 'ubuntu'
+  owner 'ubuntu'
   group 'ubuntu'
   mode '0755'
 end

--- a/3i-nodejs/recipes/setup-pm2.rb
+++ b/3i-nodejs/recipes/setup-pm2.rb
@@ -4,7 +4,7 @@ end
 
 # Set .pm2 folder permissions so ubuntu user
 # can update things
-directory '/dome/ubuntu/.pm2' do
+directory '/home/ubuntu/.pm2' do
   owner 'ubuntu'
   group 'ubuntu'
   mode '0755'


### PR DESCRIPTION
Allow nodeJS application's `npm install` that happens on deployment to receive environment variables from the application's configuration in opsworks. 

Also:
1) replaces the call to the opsworks NodejsConfiguration library with a simple chef `execute` resource
2) eliminates `- login` option from the `su` command used to set the user for the npm install command so that it receives environment from chef, not from the `deploy` user's profile
3) Moves the responsibility for installing npm dependencies from the `ti_opsworks_deploy` resource to the nodeJS specific resources so that for any given application `npm install` is only happening in one place.