### PR TITLE
Update to fix npm install

### DIFF
--- a/3i-deploy/recipes/nodejs.rb
+++ b/3i-deploy/recipes/nodejs.rb
@@ -49,7 +49,7 @@ node[:deploy].each do |application, deploy|
     notifies :restart, "service[rsyslog]", :immediately
   end
 
-  opsworks_nodejs do
+  ti_opsworks_nodejs do
     deploy_data deploy
     app application
   end


### PR DESCRIPTION
Need to use `ti_opsworks_nodejs` rather than `opsworks_nodejs` because we messed with where `npm install` is performed to address the recent SheetJS issue.